### PR TITLE
Fixed bad default on Paste class

### DIFF
--- a/ppaste_lib.py
+++ b/ppaste_lib.py
@@ -110,7 +110,9 @@ class Paste:
                  is_private=False, name=None, date=None):
         self.title = title or ''
         self.content = content or ''
-        self.hl_alias = hl_alias or 'Text only'
+        # When no highlighting is specified, we default it to text so that
+        # fragments can work properly
+        self.hl_alias = hl_alias or 'text'
         self.is_private = is_private
         self.name = PasteManager.get_rand_paste_name() \
             if name is None else name


### PR DESCRIPTION
When no `hl` field is present on the post data for uploading a new paste, the Paste constructor defaults to `Text only`, which is not a lexer by fragments when the to `get_lexer_by_name` is made by the `highlight_paste` function.
Changing the default to `text` fixes this.
