### PR TITLE
Fix raw pastes encoding

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ def view_paste_raw(paste_name=''):
     try:
         paste = ppaste_lib.PasteManager.fetch_paste(paste_name)
         resp = make_response(paste.content, 200)
-        resp.headers['Content-Type'] = 'text/plain'
+        resp.headers['Content-Type'] = 'text/plain;charset=utf-8'
         return resp
     except ppaste_lib.PPasteException as e:
         LOGGER.error(e)


### PR DESCRIPTION
Add UTF-8 charset to the Content-Type attribute of the HTTP response
sent by the server when viewing raw pastes.

Fixes #25.